### PR TITLE
New Solo Faction - Shadow Society

### DIFF
--- a/shadow/assassin
+++ b/shadow/assassin
@@ -1,0 +1,5 @@
+Assassin - ()
+- Each night, may choose to kill someone. Every kill will reward the assassin 3000 coins.
+- There will always be one Assassin present in the Shadow Society. If no more Assassins remain, one of the remaining members will be promoted to an Assassin. If there are multiple Assassins, there will be one factional kill in which the Assassins vote on who to kill.
+- Attacks are end phase and are weak attacks. The attacks will not count as visiting someone.
+- Does not respawn.


### PR DESCRIPTION
Every member of the Shadow Society will not respawn after death, however they will have a factional kill, in which there is always one Assassin. If no Assassins remain, one of the remaining members is elected as the new Assassin. The members will not receive any money from phase changes, as they will not have some facilities, such as the office, forge and bank. However, they will be able to access their own vault, stash and market. In order to earn money, they must successfully kill members from other factions.

Each member will have strong protection until attacked, at which point they must pay 5000 to purchase strong protection that lasts until attacked. They will be alerted if they are attacked. There are multiple roles to this faction, which I will soon include in this pull request.