### PR TITLE
New Buff for Prince required!

### DIFF
--- a/royalty/prince
+++ b/royalty/prince
@@ -1,4 +1,4 @@
 Prince- (6)
 - Takes the place of the king, if they are alive when the king dies.
-- Has no other abilities.
+- Has no other abilities. [NEW ROLE ABILITY REQUIRED]
 - Respawns in 2 phases as a prince, cannot respawn as a king.

--- a/royalty/prince
+++ b/royalty/prince
@@ -1,4 +1,4 @@
 Prince- (6)
 - Takes the place of the king, if they are alive when the king dies.
-- Has no other abilities. [NEW ROLE ABILITY REQUIRED]
+- When the prince takes the place of the king, they receive a one-time donation of [Number of teammates alive or respawning * 400] coins. (This includes the prince.)
 - Respawns in 2 phases as a prince, cannot respawn as a king.


### PR DESCRIPTION
Due to the recent implementation of a new Royalty system and three extra roles (Jack, Queen & Princess) which both replace the King and have an extra ability, the Prince now seems relatively weak in comparison. We need to think of a new buff for the Prince which would balance the current disadvantage of the Prince having no other ability which would also be more appealing to use. Currently I do not know anything we could do to buff the Prince role, however when I do, I will put my ideas in this discussion. Feel free to suggest any ideas you may have that could potentially become the buff for the Prince.